### PR TITLE
Server administration - Channel Management & UserAccounts

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -43,6 +43,13 @@ Channel
     :members:
 
 
+UserAccount
+--------
+
+.. automodule:: teamtalk.user_account
+    :members:
+
+
 User
 --------
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -24,8 +24,10 @@ Added
 
 - Added the possibility to get and update TeamTalk Server properties.
 - Added the possibility to create, delete, get and list user accounts.
+- Added the possibility to create and delete channels.
 - Added a teamtalk.UserAccount and teamtalk.BannedUserAccount type.
 - Added a method that can list banned users.
+- Added methods to get a channel from a path and a path from a channel.
 - Added methods to make or remove a user as a channel operator.
 
 Changed / Fixed
@@ -34,6 +36,7 @@ Changed / Fixed
 - Changed the way we check for permissions. If the bot is admin, it will have all
     permissions. If it is not, it will only have the permissions that are set
     for the bot's user account.
+- Fixed the teamtalk.Instance.get_channel function so it now returns correctly.
 - Fixed kicking and banning users. We now handle the case where the bot is not
     admin.
 - Fixed kicking and banning users. We now handle more errors and raise when appropriate.

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -16,6 +16,32 @@ This document holds a human-readable list of changes between releases.
 
     For more information on SemVer, please visit http://semver.org/.
 
+v1.0.0 - unreleased
+-----------------------------
+
+Added
+~~~~~
+
+- Added the possibility to get and update TeamTalk Server properties.
+- Added the possibility to create, delete, get and list user accounts.
+- Added a teamtalk.UserAccount and teamtalk.BannedUserAccount type.
+- Added a method that can list banned users.
+
+Changed / Fixed
+~~~~~~~~~~~~~~~
+
+- Changed the way we check for permissions. If the bot is admin, it will have all
+    permissions. If it is not, it will only have the permissions that are set
+    for the bot's user account.
+- Fixed kicking and banning users. We now handle the case where the bot is not
+    admin.
+- Fixed kicking and banning users. We now handle more errors and raise when appropriate.
+- Fixed a bug where it was impossible to get the server from the channel class
+    when using it as part of a chain.
+- Fixed a bug where it was impossible to get the server from the user class
+    when using it as part of a chain.
+- Fixed a bug where the sdk downloader would not work on linux, due to missing a user agent.
+
 
 
 :version:`1.0.0` - 2023-03-01

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -26,6 +26,7 @@ Added
 - Added the possibility to create, delete, get and list user accounts.
 - Added a teamtalk.UserAccount and teamtalk.BannedUserAccount type.
 - Added a method that can list banned users.
+- Added methods to make or remove a user as a channel operator.
 
 Changed / Fixed
 ~~~~~~~~~~~~~~~

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -24,7 +24,7 @@ Added
 
 - Added the possibility to get and update TeamTalk Server properties.
 - Added the possibility to create, delete, get and list user accounts.
-- Added the possibility to create and delete channels.
+- Added the possibility to create, update and delete channels.
 - Added a teamtalk.UserAccount and teamtalk.BannedUserAccount type.
 - Added a method that can list banned users.
 - Added methods to get a channel from a path and a path from a channel.

--- a/teamtalk/__init__.py
+++ b/teamtalk/__init__.py
@@ -26,7 +26,7 @@ except:
 
 from .bot import TeamTalkBot
 from .channel import Channel
-from .enums import TeamTalkServerInfo, UserStatusMode
+from .enums import TeamTalkServerInfo, UserStatusMode, UserType
 from .instance import TeamTalkInstance
 from .message import BroadcastMessage, ChannelMessage, CustomMessage, DirectMessage
 from .permission import Permission

--- a/teamtalk/_utils.py
+++ b/teamtalk/_utils.py
@@ -86,6 +86,49 @@ def _get_tt_obj_attribute(obj, attr):
     raise AttributeError(f"Could not find attribute {name} in {obj}")
 
 
+def _set_tt_obj_attribute(obj, attr, value):
+    name = ""
+    for name_part in attr.split("_"):
+        # if the name_part is "id" or "ID" then we want to keep it as "ID"
+        if name_part.lower() == "id":
+            name += "ID"
+        else:
+            # otherwise we want to capitalize the first letter
+            name += name_part.capitalize()
+    # first try to prefix with "n" and then set obj.name to value
+    try:
+        setattr(obj, f"n{name}", value)
+        return
+    except AttributeError:
+        pass
+    # if that fails, try to prefix name with "sz" and then set obj.name to value
+    try:
+        setattr(obj, f"sz{name}", value)
+        return
+    except AttributeError:
+        pass
+    # if that fails, try to prefix name with "b" and then set obj.name to value
+    try:
+        setattr(obj, f"b{name}", value)
+        return
+    except AttributeError:
+        pass
+    # if that fails, try to prefix name with "u" and then set obj.name to value
+    try:
+        setattr(obj, f"u{name}", value)
+        return
+    except AttributeError:
+        pass
+    # if that fails, try to lowercase the first letter name and then set obj.name to value
+    try:
+        setattr(obj, f"{name[0].lower()}{name[1:]}", value)
+        return
+    except AttributeError:
+        pass
+    # if we are still here we failed to get the attribute
+    raise AttributeError(f"Could not set attribute {name} in {obj}")
+
+
 def _do_after(delay, func):
     def _do_after_thread(delay, func):
         initial_time = time.time()

--- a/teamtalk/_utils.py
+++ b/teamtalk/_utils.py
@@ -28,6 +28,20 @@ def _waitForCmdSuccess(ttclient, cmdid, timeout):
     return False, sdk.TTMessage()
 
 
+def _waitForCmd(ttclient, cmdid, timeout):
+    end = timestamp() + timeout
+    while True:
+        msg = ttclient.getMessage()
+        if msg.nClientEvent == sdk.ClientEvent.CLIENTEVENT_CMD_ERROR:
+            if msg.nSource == cmdid:
+                return False, msg.clienterrormsg
+        elif msg.nClientEvent == sdk.ClientEvent.CLIENTEVENT_CMD_SUCCESS:
+            if msg.nSource == cmdid:
+                return True, msg
+        if timestamp() >= end:
+            return False, sdk.TTMessage()
+
+
 def _getAbsTimeDiff(t1, t2):
     t1 = int(round(t1 * 1000))
     t2 = int(round(t2 * 1000))

--- a/teamtalk/channel.py
+++ b/teamtalk/channel.py
@@ -2,7 +2,8 @@
 
 from typing import List, Union
 
-from ._utils import _get_tt_obj_attribute
+from ._utils import _get_tt_obj_attribute, _set_tt_obj_attribute, _waitForCmd
+from .permission import Permission
 from .exceptions import PermissionError
 from .implementation.TeamTalkPy import TeamTalk5 as sdk
 from .tt_file import RemoteFile
@@ -30,6 +31,43 @@ class Channel:
             self.id = channel.nChannelID
             self.channel_path = channel.szName
         self.server = self.teamtalk.server
+
+    def update(self) -> bool:
+        """Update the channel information.
+
+        Example:
+            >>> channel = teamtalk.get_channel(1)
+            >>> channel.name = "New Channel Name"
+            >>> channel.update()
+
+        Raises:
+            PermissionError: If the bot does not have permission to update the channel.
+            ValueError: If the channel could not be updated.
+
+        Returns:
+            bool: True if the channel was updated successfully.
+        """
+        if not self.teamtalk.has_permission(Permission.MODIFY_CHANNELS) or not sdk._IsChannelOperator(
+            self._tt, self.super.getMyUserID(), self.id
+        ):
+            raise PermissionError("the bot does not have permission to update the channel.")
+        result = sdk._DoUpdateChannel(self.teamtalk._tt, self._channel)
+        if result == -1:
+            raise ValueError("Channel could not be updated")
+        cmd_result, cmd_err = _waitForCmd(self.super, result, 2000)
+        if not cmd_result:
+            err_nr = cmd_err.nErrorNo
+            if err_nr == sdk.ClientError.CMDERR_NOT_LOGGEDIN:
+                raise PermissionError("The bot is not logged in")
+            if err_nr == sdk.ClientError.CMDERR_NOT_AUTHORIZED:
+                raise PermissionError("The bot does not have permission to update channels")
+            if err_nr == sdk.ClientError.CMDERR_CHANNEL_NOT_FOUND:
+                raise ValueError("Channel could not be found")
+            if err_nr == sdk.ClientError.CMDERR_CHANNEL_ALREADY_EXISTS:
+                raise ValueError("Channel already exists")
+            if err_nr == sdk.ClientError.CMDERR_CHANNEL_HAS_USERS:
+                raise ValueError("Channel has users and can therefore not be updated")
+        return True
 
     def _refresh(self) -> None:
         self._channel, self.channel_path = self.teamtalk._get_channel_info(self.id)
@@ -125,6 +163,29 @@ class Channel:
             return self.__dict__[name]
         else:
             return _get_tt_obj_attribute(self._channel, name)
+
+    def __setattr__(self, name: str, value):
+        """Try to set the specified attribute.
+
+        Args:
+            name: The name of the attribute.
+            value: The value to set the attribute to.
+
+        Raises:
+            AttributeError: If the specified attribute is not found. This is the default behavior. # noqa
+        """
+        if name in dir(self):
+            self.__dict__[name] = value
+        else:
+            # id cannot be change.
+            if name == "id":
+                raise AttributeError("Cannot change the id of a channel")
+            if name in ["teamtalk", "id", "server", "channel_path", "_channel"]:
+                self.__dict__[name] = value
+            else:
+                _get_tt_obj_attribute(self.properties, name)
+                # if we have gotten here, we can set the attribute
+                _set_tt_obj_attribute(self._channel, name, value)
 
 
 class _ChannelTypeMeta(type):

--- a/teamtalk/channel.py
+++ b/teamtalk/channel.py
@@ -125,3 +125,13 @@ class Channel:
             return self.__dict__[name]
         else:
             return _get_tt_obj_attribute(self._channel, name)
+
+
+class _ChannelTypeMeta(type):
+    def __getattr__(cls, name: str) -> sdk.UserRight:
+        name = f"CHANNEL_{name}"
+        return getattr(sdk.ChannelType, name, None)
+
+
+class ChannelType(metaclass=_ChannelTypeMeta):
+    """A class representing user permissions in TeamTalk."""

--- a/teamtalk/enums.py
+++ b/teamtalk/enums.py
@@ -112,3 +112,10 @@ class UserStatusMode:
     ONLINE = 0
     AWAY = 1
     QUESTION = 2
+
+
+class UserType:
+    """The type of a user account."""
+
+    DEFAULT = 0x1
+    ADMIN = 0x02

--- a/teamtalk/instance.py
+++ b/teamtalk/instance.py
@@ -213,6 +213,90 @@ class TeamTalkInstance(sdk.TeamTalk):
         """
         return self.bot, TeamTalkChannel(self, channel_id)
 
+    def make_channel_operator(
+        self, user: Union[TeamTalkUser, int], channel: Union[TeamTalkUser, int], operator_password: str = ""
+    ) -> bool:
+        """Makes a user the channel operator.
+
+        Args:
+            user: The user to make the channel operator.
+            channel: The channel to make the user the channel operator in.
+            operator_password: The operator password of the channel.
+
+        Raises:
+            TypeError: If the user or channel is not of type teamtalk.User or int.
+            PermissionError: If the bot doesn't have the permission to make a user the channel operator.
+            ValueError: If the user or channel is not found.
+
+        Returns:
+            bool: True if the user was made the channel operator, False otherwise.
+        """
+        if isinstance(user, int):
+            user = self.get_user(user)
+        if isinstance(channel, int):
+            channel = self.get_channel(channel)
+        result = sdk.DoChannelOpEx(self.super, user.id, channel.id, sdk.ttstr(operator_password), True)
+        if result == -1:
+            raise PermissionError("The bot does not have the permission to make a user the channel operator")
+            return False
+        cmd_result, cmd_err = _waitForCmd(self.super, result, 2000)
+        if not cmd_result:
+            err_nr = cmd_err.nErrorNo
+            if err_nr == sdk.ClientError.CMDERR_NOT_LOGGEDIN:
+                raise PermissionError("The bot is not logged in")
+            if err_nr == sdk.ClientError.CMDERR_NOT_AUTHORIZED:
+                raise PermissionError("The bot does not have permission to make a user the channel operator")
+            if err_nr == sdk.ClientError.CMDERR_CHANNEL_NOT_FOUND:
+                raise ValueError("The channel does not exist")
+            if err_nr == sdk.ClientError.CMDERR_USER_NOT_FOUND:
+                raise ValueError("The user does not exist")
+            if err_nr == sdk.ClientError.CMDERR_INCORRECT_OP_PASSWORD:
+                raise ValueError("The operator password is incorrect")
+            return False
+        return True
+
+    def remove_channel_operator(
+        self, user: Union[TeamTalkUser, int], channel: Union[TeamTalkUser, int], operator_password: str = ""
+    ) -> bool:
+        """Removes a user as the channel operator.
+
+        Args:
+            user: The user to make the channel operator.
+            channel: The channel to make the user the channel operator in.
+            operator_password: The operator password of the channel.
+
+        Raises:
+            TypeError: If the user or channel is not of type teamtalk.User or int.
+            PermissionError: If the bot doesn't have the permission to make a user the channel operator.
+            ValueError: If the channel or user does not exist.
+
+        Returns:
+            bool: True if the user was removed as the channel operator, False otherwise.
+        """
+        if isinstance(user, int):
+            user = self.get_user(user)
+        if isinstance(channel, int):
+            channel = self.get_channel(channel)
+        result = sdk.DoChannelOpEx(self.super, user.id, channel.id, sdk.ttstr(operator_password), False)
+        if result == -1:
+            raise PermissionError("The bot does not have the permission to make a user the channel operator")
+            return False
+        cmd_result, cmd_err = _waitForCmd(self.super, result, 2000)
+        if not cmd_result:
+            err_nr = cmd_err.nErrorNo
+            if err_nr == sdk.ClientError.CMDERR_NOT_LOGGEDIN:
+                raise PermissionError("The bot is not logged in")
+            if err_nr == sdk.ClientError.CMDERR_NOT_AUTHORIZED:
+                raise PermissionError("The bot does not have permission to make a user the channel operator")
+            if err_nr == sdk.ClientError.CMDERR_CHANNEL_NOT_FOUND:
+                raise ValueError("The channel does not exist")
+            if err_nr == sdk.ClientError.CMDERR_USER_NOT_FOUND:
+                raise ValueError("The user does not exist")
+            if err_nr == sdk.ClientError.CMDERR_INCORRECT_OP_PASSWORD:
+                raise ValueError("The operator password is incorrect")
+            return False
+        return True
+
     def get_user(self, user_id: int) -> TeamTalkUser:
         """Gets a user by its ID.
 

--- a/teamtalk/instance.py
+++ b/teamtalk/instance.py
@@ -636,7 +636,7 @@ class TeamTalkInstance(sdk.TeamTalk):
             _log.debug(f"Kicking user {user} from channel {channel}")
             self._do_cmd(user, channel, "_DoKickUser")
         else:  # channel
-            if not self.has_permission(Permission.KICK_USERS_FROM_CHANNEL) or sdk._IsChannelOperator(
+            if not self.has_permission(Permission.KICK_USERS_FROM_CHANNEL) or not sdk._IsChannelOperator(
                 self._tt, self.super.getMyUserID(), channel
             ):
                 raise PermissionError("You do not have permission to kick users from channels")

--- a/teamtalk/instance.py
+++ b/teamtalk/instance.py
@@ -130,6 +130,8 @@ class TeamTalkInstance(sdk.TeamTalk):
     def has_permission(self, permission: Permission) -> bool:
         """Checks if the bot has a permission.
 
+        If the user is an admin, they have all permissions.
+
         Args:
             permission: The permission to check for.
 
@@ -137,6 +139,9 @@ class TeamTalkInstance(sdk.TeamTalk):
             bool: True if the bot has the permission, False otherwise.
         """
         user = self.super.getMyUserAccount()
+        # first check if they are an admin
+        if user.uUserType == sdk.UserType.USERTYPE_ADMIN:
+            return True
         user_rights = user.uUserRights
         return (user_rights & permission) == permission
 

--- a/teamtalk/server.py
+++ b/teamtalk/server.py
@@ -1,8 +1,10 @@
 """Provides the Server class for interacting with a TeamTalk5 server."""
 
+import ctypes
 from typing import Union
 
-from ._utils import _get_tt_obj_attribute
+from ._utils import _get_tt_obj_attribute, _set_tt_obj_attribute
+from .permission import Permission
 from .channel import Channel as TeamTalkChannel
 from .exceptions import PermissionError
 from .implementation.TeamTalkPy import TeamTalk5 as sdk
@@ -153,6 +155,30 @@ class Server:
         """
         self.teamtalk_instance.unban_user(user, 0)
 
+    def get_properties(self) -> "ServerProperties":
+        """Gets the properties of the server.
+
+        Returns:
+            A teamtalk.ServerProperties instance representing the properties of the server.
+        """
+        props = self.teamtalk_instance.super.getServerProperties()
+        return ServerProperties(self.teamtalk_instance, props)
+
+    def update_properties(self, properties: "ServerProperties"):
+        """Updates the properties of the server.
+
+        Args:
+            properties: The updated properties. See teamtalk.ServerProperties for more information.
+
+        Raises:
+            PermissionError: If the bot does not have the permission to update the properties.
+        """
+        if not self.teamtalk_instance.has_permission(Permission.UPDATE_SERVERPROPERTIES):
+            raise PermissionError("The bot does not have permission to update the server properties")
+        # get the underlying properties object
+        properties = properties.properties
+        sdk._DoUpdateServer(self.teamtalk_instance._tt, ctypes.byref(properties))
+
     def __getattr__(self, name: str):
         """Try to get the specified attribute on server.
 
@@ -169,3 +195,69 @@ class Server:
             return self.__dict__[name]
         else:
             return _get_tt_obj_attribute(self._user, name)
+
+
+class ServerProperties(object):
+    """Represents the properties of a server.
+
+    This class should not be instantiated directly. Instead, use the teamtalk.Server.get_properties() method. # noqa
+
+    Example:
+        >>> server = teamtalk server
+        >>> properties = server.get_properties()
+        >>> properties.max_users
+        1000
+        >>> properties.max_users = 500
+        >>> server.update_properties(properties)
+        >>> properties = server.get_properties()
+        >>> properties.max_users
+        500
+    """
+
+    def __init__(self, teamtalk_instance, properties):
+        """Initializes a new instance of the ServerProperties class.
+
+        Args:
+            teamtalk_instance: The teamtalk.TeamTalk instance.
+            properties: The underlying properties object.
+        """
+        self.teamtalk_instance = teamtalk_instance
+        self.properties = properties
+
+    def __getattr__(self, name: str):
+        """Try to get the specified attribute on server.
+
+        Args:
+            name: The name of the attribute.
+
+        Returns:
+            The value of the specified attribute.
+
+        Raises:
+            AttributeError: If the specified attribute is not found. This is the default behavior. # noqa
+        """
+        if name in dir(self):
+            return self.__dict__[name]
+        else:
+            return _get_tt_obj_attribute(self.properties, name)
+
+    def __setattr__(self, name: str, value):
+        """Try to set the specified attribute on properties.
+
+        Args:
+            name: The name of the attribute.
+            value: The value to set the attribute to.
+
+            Raises:
+                AttributeError: If the specified attribute is not found.
+        """
+        if name in dir(self):
+            self.__dict__[name] = value
+        else:
+            # if name is either teamtalk_instance or properties, just set it on self
+            if name in ["teamtalk_instance", "properties"]:
+                self.__dict__[name] = value
+            else:
+                _get_tt_obj_attribute(self.properties, name)
+                # if we have gotten here, we can set the attribute
+                _set_tt_obj_attribute(self.properties, name, value)

--- a/teamtalk/user_account.py
+++ b/teamtalk/user_account.py
@@ -1,0 +1,39 @@
+"""This module defines a class for a User Account on a TeamTalk server.
+
+The difference between this class and the User class is that this class represents a user account,
+while the User class represents a user that is currently connected to the server.
+"""
+
+from ._utils import _get_tt_obj_attribute
+from .implementation.TeamTalkPy import TeamTalk5 as sdk
+
+
+class UserAccount:
+    """A class for a user account on a TeamTalk server. This class is not meant to be instantiated directly. Instead, use the TeamTalkBot.list_user_accounts() method to get a list of UserAccount objects. # noqa"""
+
+    def __init__(self, teamtalk_instance, account: sdk.UserAccount) -> None:
+        """Initialize a UserAccount object.
+
+        Args:
+            teamtalk_instance: The TeamTalk instance.
+            account: The user account.
+        """
+        self.teamtalk_instance = teamtalk_instance
+        self._account = account
+
+    def __getattr__(self, name: str):
+        """Try to get the specified attribute from self._user if it is not found in self.
+
+        Args:
+            name: The name of the attribute.
+
+        Returns:
+            The value of the specified attribute.
+
+        Raises:
+            AttributeError: If the specified attribute is not found. This is the default behavior. # noqa
+        """
+        if name in dir(self):
+            return self.__dict__[name]
+        else:
+            return _get_tt_obj_attribute(self._account, name)

--- a/teamtalk/user_account.py
+++ b/teamtalk/user_account.py
@@ -37,3 +37,11 @@ class UserAccount:
             return self.__dict__[name]
         else:
             return _get_tt_obj_attribute(self._account, name)
+
+
+# make a subclass of UserAccount for a banned user
+class BannedUserAccount(UserAccount):
+    """Represents a banned user account on a TeamTalk server. This class is not meant to be instantiated directly. Instead, use the TeamTalkBot.list_banned_users() method to get a list of BannedUserAccount objects. # noqa"""
+
+    # shouldn't do anything extra
+    pass


### PR DESCRIPTION
- Added the possibility to get and update TeamTalk Server properties.
- Added the possibility to create, delete, get and list user accounts.
- Added the possibility to create, update and delete channels.
- Added a teamtalk.UserAccount and teamtalk.BannedUserAccount type.
- Added a method that can list banned users.
- Added methods to get a channel from a path and a path from a channel.
- Added methods to make or remove a user as a channel operator.
- Changed the way we check for permissions. If the bot is admin, it will have all
    permissions. If it is not, it will only have the permissions that are set
    for the bot's user account.
- Fixed the teamtalk.Instance.get_channel function so it now returns correctly.
- Fixed kicking and banning users. We now handle the case where the bot is not
    admin.
- Fixed kicking and banning users. We now handle more errors and raise when appropriate.
- Fixed a bug where it was impossible to get the server from the channel class
    when using it as part of a chain.
- Fixed a bug where it was impossible to get the server from the user class
    when using it as part of a chain.
