### PR TITLE
Fixes error caused bye not having self._tt in the subscribe function.

### DIFF
--- a/teamtalk/instance.py
+++ b/teamtalk/instance.py
@@ -187,7 +187,7 @@ class TeamTalkInstance(sdk.TeamTalk):
             user: The user to subscribe to.
             subscription: The subscription to subscribe to.
         """
-        sdk._DoSubscribe(user.id, subscription)
+        sdk._DoSubscribe(self._tt, user.id, subscription)
 
     def unsubscribe(self, user: TeamTalkUser, subscription: Subscription):
         """Unsubscribes from a subscription.


### PR DESCRIPTION
This fixes the error reported because the _tt atribute was not being sent to the sdk._DoSubscribe function