### PR TITLE
new streamer implementation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -479,18 +479,6 @@ plugins = ["importlib-metadata"]
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
-name = "pywave"
-version = "0.5.0"
-description = "Open, read and write Wave files"
-category = "main"
-optional = false
-python-versions = "*"
-files = [
-    {file = "PyWave-0.5.0-py2.py3-none-any.whl", hash = "sha256:d31bb468ff0501f0dacbe30c0d4c32aaf86d1421de2d5f08b50d428fca2bea48"},
-    {file = "PyWave-0.5.0.tar.gz", hash = "sha256:f1592fd71be7e94a4da00f0254f346e8e867893d38c15ae1fdf1872eaf61c615"},
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.1"
 description = "YAML parser and emitter for Python"
@@ -878,4 +866,4 @@ testing = ["big-O", "jaraco.functools", "jaraco.itertools", "more-itertools", "p
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9, <3.13"
-content-hash = "37c4c4faef93ba3c3aaeefba6366a5ec40335d9c1d2f103c3c58f87c4cfa3f15"
+content-hash = "1aad2ccb4755441876561fb43b04856b8e0dbaf757489906708aef733fd7b3d1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ typing-extensions = "^4.5"
 requests = "^2.28"
 beautifulsoup4 = "^4.11"
 patool = "^1.12"
-pywave = "^0.5"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/teamtalk/instance.py
+++ b/teamtalk/instance.py
@@ -859,6 +859,7 @@ class TeamTalkInstance(sdk.TeamTalk):
                 sdk.ClientEvent.CLIENTEVENT_CMD_PROCESSING,
                 sdk.ClientEvent.CLIENTEVENT_CMD_ERROR,
                 sdk.ClientEvent.CLIENTEVENT_CMD_SUCCESS,
+                sdk.ClientEvent.CLIENTEVENT_AUDIOINPUT,
             ):
                 _log.warning(f"Unhandled event: {event}")
 

--- a/teamtalk/streamer.py
+++ b/teamtalk/streamer.py
@@ -5,17 +5,22 @@ This module contains the Streamer class, which is used to stream audio data to a
 .. warning::
    To use other files than .wav files, you need to have ffmpeg installed on your system.
 
+.. warning::
+   To stream urls, you need to have yt-dlp installed on your system.
+
 Example:
     >>> import teamtalk
     >>> # asuming we have a bot in the variable bot
     >>> @bot.event
     >>> async def on_message(message):
     >>>     if message.content.lower() == "play":
-    >>>         stream = teamtalk.Streamer(message.channel)
-    >>>         stream.stream_file("test.wav")
+    >>>         streamer = teamtalk.Streamer.get_streamer_for_channel(message.channel)
+    >>>         streamer.stream("path/to/file.wav")
+    >>> # or for an url
+    >>> streamer.stream("https://www.example.com/youtube/or/other/stream")
 
 
-It's also possible to stream audio from an arbitrary data stream, such as a microphone or a url stream.
+It's also possible to stream audio from an arbitrary data stream, such as a microphone.
 To do this, you need to set the correct sample rate and number of channels on initialization,
 and then feed the data to the streamer as it becomes available.
 The data needs to be in 16 bit PCM format (pcm_s16le).
@@ -26,35 +31,53 @@ Example:
     >>> @bot.event
     >>> async def on_message(message):
     >>>     if message.content.lower() == "play":
-    >>>         stream = teamtalk.Stream(message.channel, sample_rate=48000, channels=2)
-    >>>         # we could get the data from any source, so let's assume it's coming from a live microphone and/or url stream
-    >>>         data_stream = # connect to microphone and/or url stream
+    >>>         streamer = teamtalk.Streamer.get_streamer_for_channel(message.channel, sample_rate=48000, channels=2)
+    >>>         # we could get the data from any source, so let's assume it's coming from a live microphone.
+    >>>         data_stream = # connect to microphone
     >>>         while True:
     >>>             # get the data from the stream
     >>>             data = data_stream.read(streamer.block_size*16) # we are reading 16 chunks at a time to combat buffering
     >>>             if data == 0:
     >>>                 break
     >>>             # add the data to the streamer
-    >>>             stream.feed(data)
-    >>>         # close the connection to our microphone and/or url stream
+    >>>             streamer.feed(data)
+    >>>         # close the connection to our microphone
 """
 
-import os
 import ctypes
 import threading
 import random
 import subprocess
-import tempfile
-
-import PyWave
+import multiprocessing
 
 from .implementation.TeamTalkPy import TeamTalk5 as sdk
 
 from .channel import Channel as TeamTalkChannel
 
+_audio_streamers = {}
+
 
 class Streamer:
     """A class representing a streamer for audio data to a TeamTalk channel."""
+
+    @staticmethod
+    def get_streamer_for_channel(
+        channel: TeamTalkChannel, sample_rate: int = 48000, channels: int = 2, block_size: int = 4 * 1024
+    ):
+        """Gets a streamer for a channel.
+
+        Args:
+            channel (TeamTalkChannel): The TeamTalk channel to get the streamer for.
+            sample_rate (int, optional): The sample rate of the audio data. Defaults to 48000.
+            channels (int, optional): The number of channels in the audio data. Defaults to 2.
+            block_size (int, optional): The block size of the audio data. Defaults to 4 * 1024 (4kb)
+
+        Returns:
+            Streamer: The streamer for the channel.
+        """
+        if channel not in _audio_streamers:
+            _audio_streamers[channel] = Streamer(channel, sample_rate, channels, block_size)
+        return _audio_streamers[channel]
 
     def __init__(self, channel: TeamTalkChannel, sample_rate: int = 48000, channels: int = 2, block_size: int = 4 * 1024):
         """Initializes a new instance of the TeamTalkStreamer class.
@@ -74,9 +97,16 @@ class Streamer:
         self.current_data = b""
         # streamer id
         self.stream_id = random.randint(6000, 6999)
+        # capabilities for  ffmpeg and yt-dlp
+        self.ffmpeg_available = self._has_ffmpeg()
+        self.yt_dlp_available = self._has_yt_dlp()
         # start the stream function on another thread
         self.running = True
-        threading.Thread(target=self._do_stream).start()
+        self._streamer_thread = threading.Thread(target=self._do_stream, daemon=True)
+        self._streamer_thread.start()
+        self._current_streamer_thread = None
+        self._current_streamer_running = False
+        self._stream_lock = threading.Lock()  # To ensure mutual exclusion when starting/stopping streams.
 
     def __del__(self):
         """Shuts down the streamer by adding a null-block to the blocks list and waiting for the blocks list to be empty."""
@@ -88,39 +118,126 @@ class Streamer:
         # stop the streamer
         self.running = False
 
-    def stream_file(self, filepath: str, _tried: int = 0) -> int:
-        """Streams a file to the channel.
+    def stream(self, path: str) -> None:
+        """Streams a file or url to the channel.
 
         Args:
-            filepath (str): The path to the file to stream.
-
-        Returns:
-            int: The stream id of the stream.
+            path (str): The path to the file or url to stream.
 
         Raises:
-            FileNotFoundError: If the file could not be found.
-            RuntimeError: If the file could not be opened as a wav file or if the file could not be converted to a wav file.
+            RuntimeError: If yt-dlp is not installed and the path is an url, or ffmpeg is not installed.
+            KeyboardInterrupt: If the stream is interrupted by a keyboard interrupt.
         """
-        if not os.path.isfile(filepath):
-            raise FileNotFoundError(f"Could not find file {filepath}")
+        with self._stream_lock:
+            self._request_stop_stream()  # Gracefully request the current stream to stop.
+            self._wait_for_cleanup()  # Wait for the cleanup to complete.
+            self._start_new_stream(path)  # Start the new stream.
+
+    def _request_stop_stream(self):
+        if self._current_streamer_thread is not None:
+            self._current_streamer_running = False
+
+    def _wait_for_cleanup(self):
+        if self._current_streamer_thread:
+            self.blocks.clear()  # Clear the blocks list, ensuring the streamer stops.
+            self.blocks.append(b"")
+
+    def _start_new_stream(self, path):
+        self._current_streamer_running = True
+        self._current_streamer_thread = threading.Thread(target=self._stream, args=(path,), daemon=True)
+        self._current_streamer_thread.start()
+
+    def _stream(self, path: str) -> None:
+        if not self.ffmpeg_available:
+            raise RuntimeError("Could not convert file to wav. ffmpeg is not installed.")
+        if path.startswith("http"):
+            if not self.yt_dlp_available:
+                raise RuntimeError("Could not download file. yt-dlp is not installed.")
+            ffmpeg_process, yt_dlp_process = self._get_url_data(path)
+        else:
+            ffmpeg_command = [
+                'ffmpeg',
+                '-i',
+                path,  # Input URL
+                '-f',
+                'wav',  # Output format
+                '-acodec',
+                'pcm_s16le',  # Audio codec
+                '-ar',
+                f"{str(self.sample_rate)}",  # Sample rate
+                '-ac',
+                str(self.channels),  # Number of audio channels
+                '-threads',
+                str(multiprocessing.cpu_count()),  # Number of threads
+                '-hide_banner',
+                '-loglevel',
+                'error',  # Suppress output
+                '-',  # Output to stdout
+            ]
+            ffmpeg_process = subprocess.Popen(ffmpeg_command, stdout=subprocess.PIPE)
         try:
-            wf = PyWave.open(filepath, "r")
-        except PyWave.PyWaveError:
-            if _tried < 3:
-                new_filepath = self._convert_to_wav(filepath)
-                return self.stream_file(new_filepath, _tried=_tried + 1)
-            else:
-                raise RuntimeError(f"Could not open file {filepath}.")
-            # not normally done, but since we have a file, we don't need to asume
-        self.sample_rate = wf.frequency
-        self.channels = wf.channels
-        while True:
-            block = wf.read(self.block_size * 16)
-            if len(block) == 0:
-                break
-            self.feed(block)
-        wf.close()
-        return self.stream_id
+            while self._current_streamer_running:
+                block = ffmpeg_process.stdout.read(self.block_size)
+                if len(block) == 0:
+                    break
+                self.feed(block)
+        except KeyboardInterrupt:
+            raise
+        finally:
+            self._graceful_shutdown(ffmpeg_process)
+            if path.startswith("http"):
+                self._graceful_shutdown(yt_dlp_process)
+
+    def _get_url_data(self, url):
+        yt_dlp_command = [
+            'yt-dlp',
+            '-f',
+            'bestaudio',
+            '--extract-audio',
+            '--audio-format',
+            'best',
+            '--audio-quality',
+            '0',
+            '--quiet',
+            '-o',
+            '-',
+            url,
+        ]
+        ffmpeg_command = [
+            'ffmpeg',
+            '-i',
+            'pipe:0',
+            '-f',
+            'wav',
+            '-acodec',
+            'pcm_s16le',
+            '-ar',
+            str(self.sample_rate),
+            '-ac',
+            str(self.channels),
+            '-threads',
+            str(multiprocessing.cpu_count()),
+            '-hide_banner',
+            '-loglevel',
+            'error',
+            '-',
+        ]
+
+        yt_dlp_process = subprocess.Popen(yt_dlp_command, stdout=subprocess.PIPE)
+        return subprocess.Popen(ffmpeg_command, stdin=yt_dlp_process.stdout, stdout=subprocess.PIPE), yt_dlp_process
+
+    def _graceful_shutdown(self, process):
+        if process:
+            process.terminate()  # Send SIGTERM
+            try:
+                process.wait(timeout=2)  # Wait for up to 5 seconds for the process to exit
+            except subprocess.TimeoutExpired:
+                process.kill()  # Force kill if it doesn't terminate in time
+            finally:
+                if process.stdout:
+                    process.stdout.close()
+                if process.stderr:
+                    process.stderr.close()
 
     def feed(self, data: bytes) -> int:
         """Feeds data to the streamer.
@@ -166,31 +283,20 @@ class Streamer:
                 # remove the block from the blocks list
                 self.blocks = self.blocks[1:]
 
-    def _convert_to_wav(self, filepath):
-        if not self._has_ffmpeg():
-            raise RuntimeError("Could not convert file to wav. ffmpeg is not installed.")
-        # get a path to a temp dir we can write to
-        temp_dir = tempfile.gettempdir()
-        # make sure it exists
-        if not os.path.isdir(temp_dir):
-            os.makedirs(temp_dir)
-        # get a path to a randomly named temp file
-        temp_file = os.path.join(temp_dir, next(tempfile._get_candidate_names()))
-        # add a wav extension to the temp file
-        temp_file = f"{temp_file}.wav"
-        cmd = ["ffmpeg", "-i", filepath, "-acodec", "pcm_s16le", temp_file]
-        # call our command, prinitng stdout and stderr if we fail
-        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        if result.returncode != 0:
-            print(result.stdout)
-            print(result.stderr)
-            raise RuntimeError(f"Could not convert file {filepath} to wav.")
-        return temp_file
-
     def _has_ffmpeg(self):
         # check if ffmpeg is installed
         try:
             result = subprocess.run(["ffmpeg", "-version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            if result.returncode != 0:
+                return False
+        except FileNotFoundError:
+            return False
+        return True
+
+    def _has_yt_dlp(self):
+        # check if yt-dlp is installed
+        try:
+            result = subprocess.run(["yt-dlp", "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
             if result.returncode != 0:
                 return False
         except FileNotFoundError:


### PR DESCRIPTION
This pr redesigns the streamer implementation.

Now we can stream from any file on disk as well as any url that yt-dlp supports.

This also means, that for any other capabilities than feeding audio directly to the streamer, a soft dependency on ffmpeg and yt-dlp has been set.

* If only ffmpeg is found, only local file streaming is supported.
* If yt-dlp is also found, streaming from urls are also supported.

In addition, this also adds a stop functions, as well as the possibility of adjusting volume, and muting the left or right channel, something that wasn't possible before.