### PR TITLE
Fix linux issues do to improper use of ttstr.

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -29,7 +29,7 @@ Fixed
 
 - Fixed various recursion errors when trying to get underlying SDK properties from a teamtalk.Channel.
 - Fixed PermissionError when trying to kick a user from a channel.
-
+- Fixed errors on linux with certain functions do to improper use of sdk.ttstr.
 
 :version:`1.2.1` - 2024-07-12
 ---------------------------------

--- a/teamtalk/channel.py
+++ b/teamtalk/channel.py
@@ -92,7 +92,7 @@ class Channel:
         msg.nFromUserID = self.teamtalk.getMyUserID()
         msg.szFromUsername = self.teamtalk.getMyUserAccount().szUsername
         msg.nChannelID = self.id
-        msg.szMessage = content
+        msg.szMessage = sdk.ttstr(content)
         msg.bMore = False
         # get a pointer to our message
         self.teamtalk._send_message(msg, **kwargs)

--- a/teamtalk/instance.py
+++ b/teamtalk/instance.py
@@ -123,7 +123,7 @@ class TeamTalkInstance(sdk.TeamTalk):
         Args:
             nickname: The new nickname.
         """
-        self.super.doChangeNickname(nickname)
+        self.super.doChangeNickname(sdk.ttstr(nickname))
 
     def change_status(self, status_mode: UserStatusMode, status_message: str):
         """Changes the status of the bot.
@@ -132,7 +132,7 @@ class TeamTalkInstance(sdk.TeamTalk):
             status_mode: The status mode.
             status_message: The status message.
         """
-        self.super.doChangeStatus(status_mode, status_message)
+        self.super.doChangeStatus(status_mode, sdk.ttstr(status_message))
 
     # permission stuff
     def has_permission(self, permission: Permission) -> bool:
@@ -231,7 +231,7 @@ class TeamTalkInstance(sdk.TeamTalk):
         Args:
             channel: The channel to join.
         """
-        self.super.doJoinChannelByID(channel.id, sdk.ttstr(channel.password))
+        self.super.doJoinChannelByID(channel.id, channel.password)
 
     def leave_channel(self):
         """Leaves the current channel."""


### PR DESCRIPTION
This pull request fixes issues with linux and ctypes throwing errors because ttstr was not being used in the right places.
- **Fixes incorrect usage of ttstr in instance class.**
- **update docs.**
